### PR TITLE
Remove network access

### DIFF
--- a/com.xnview.XnRetro.yaml
+++ b/com.xnview.XnRetro.yaml
@@ -9,9 +9,6 @@ finish-args:
   - --socket=x11
   # Filesystem access
   - --filesystem=home
-  # Network access
-  # for Share
-  - --share=network
   # OpenGL access
   - --device=dri
   # 32-bit execution


### PR DESCRIPTION
None of the share functions work anymore due to API issues and the app requires too old openssl, which we are unable to bundle in the manifest

See https://github.com/flathub/com.xnview.XnRetro/pull/8 for openssl issues, I tried.

Additionally, the app is also abandoned so this won't be fixed.